### PR TITLE
disable tracing for gRPC

### DIFF
--- a/rpc_test.go
+++ b/rpc_test.go
@@ -361,6 +361,7 @@ func BenchmarkProtoHTTP1_64K(b *testing.B) {
 }
 
 func init() {
+	grpc.EnableTracing = false
 	devNull, err := os.Open(os.DevNull)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
tracing may introduce visible impact especially when payload is large.

BTW, generated code need to be sync-ed because there was a codegen change recently.