### PR TITLE
Fix unclosed channel

### DIFF
--- a/rpc_test.go
+++ b/rpc_test.go
@@ -77,10 +77,10 @@ func benchmarkEcho(b *testing.B, size int, accept func(net.Listener, *tls.Config
 		}
 	}()
 
-	errChan := make(chan error)
 	go func() {
-		errChan <- accept(listener, tlsConfig)
-		close(errChan)
+		if err := accept(listener, tlsConfig); err != nil && !strings.HasSuffix(err.Error(), "use of closed network connection") {
+			b.Fatal(err)
+		}
 	}()
 
 	if setup != nil {
@@ -106,12 +106,6 @@ func benchmarkEcho(b *testing.B, size int, accept func(net.Listener, *tls.Config
 
 	if teardown != nil {
 		teardown()
-	}
-
-	for err := range errChan {
-		if err != nil && !strings.HasSuffix(err.Error(), "use of closed network connection") {
-			b.Fatal(err)
-		}
 	}
 }
 


### PR DESCRIPTION
Since `http.Server#Serve` blocks indefinitely on success, `errChan` was never closing and would cause the tests to fail.

Example failure:
```
$ go test -bench=GRPCServeHTTP -benchmem -benchtime 1s -timeout 10s
SIGQUIT: quit
PC=0x7fff77d637de m=0 sigcode=0

goroutine 0 [idle]:
runtime.pthread_cond_wait(0x1a56340, 0x1a56300, 0x7ffe00000000)
	/usr/local/Cellar/go/1.11.4/libexec/src/runtime/sys_darwin.go:302 +0x51
runtime.semasleep(0xffffffffffffffff, 0x0)
	/usr/local/Cellar/go/1.11.4/libexec/src/runtime/os_darwin.go:63 +0x85
runtime.notesleep(0x1a56100)
	/usr/local/Cellar/go/1.11.4/libexec/src/runtime/lock_sema.go:167 +0xe3
runtime.stopm()
	/usr/local/Cellar/go/1.11.4/libexec/src/runtime/proc.go:2016 +0xe3
runtime.findrunnable(0xc000032500, 0x0)
	/usr/local/Cellar/go/1.11.4/libexec/src/runtime/proc.go:2487 +0x4dc
runtime.schedule()
	/usr/local/Cellar/go/1.11.4/libexec/src/runtime/proc.go:2613 +0x13a
runtime.park_m(0xc0001bc900)
	/usr/local/Cellar/go/1.11.4/libexec/src/runtime/proc.go:2676 +0xae
runtime.mcall(0x105aedb)
	/usr/local/Cellar/go/1.11.4/libexec/src/runtime/asm_amd64.s:299 +0x5b

goroutine 1 [chan receive, 1 minutes]:
testing.(*B).run1(0xc0000be000, 0xc0000be000)
	/usr/local/Cellar/go/1.11.4/libexec/src/testing/benchmark.go:216 +0x9e
testing.(*B).Run(0xc00017a340, 0x15ff5a0, 0x19, 0x1617c20, 0x10e7a00)
	/usr/local/Cellar/go/1.11.4/libexec/src/testing/benchmark.go:514 +0x275
testing.runBenchmarks.func1(0xc00017a340)
	/usr/local/Cellar/go/1.11.4/libexec/src/testing/benchmark.go:416 +0x78
testing.(*B).runN(0xc00017a340, 0x1)
	/usr/local/Cellar/go/1.11.4/libexec/src/testing/benchmark.go:141 +0xb2
testing.runBenchmarks(0x1603483, 0x20, 0xc00000c200, 0x1a4b7c0, 0xd, 0xd, 0x80)
	/usr/local/Cellar/go/1.11.4/libexec/src/testing/benchmark.go:422 +0x323
testing.(*M).Run(0xc00015a100, 0x0)
	/usr/local/Cellar/go/1.11.4/libexec/src/testing/testing.go:1040 +0x37c
main.main()
	_testmain.go:66 +0x13d

goroutine 8 [chan receive]:
github.com/cockroachdb/rpc-bench.benchmarkEcho(0xc0000be000, 0x400, 0x1617cb0, 0xc0000e1f18, 0xc0000e1f00, 0xc0000ce360)
	/Users/isobel/go/src/github.com/cockroachdb/rpc-bench/rpc_test.go:111 +0x47f
github.com/cockroachdb/rpc-bench.benchmarkEchoGRPC(0xc0000be000, 0x1617cb0, 0x400)
	/Users/isobel/go/src/github.com/cockroachdb/rpc-bench/rpc_test.go:144 +0x119
github.com/cockroachdb/rpc-bench.BenchmarkGRPCServeHTTP_1K(0xc0000be000)
	/Users/isobel/go/src/github.com/cockroachdb/rpc-bench/rpc_test.go:246 +0x40
testing.(*B).runN(0xc0000be000, 0x1)
	/usr/local/Cellar/go/1.11.4/libexec/src/testing/benchmark.go:141 +0xb2
testing.(*B).run1.func1(0xc0000be000)
	/usr/local/Cellar/go/1.11.4/libexec/src/testing/benchmark.go:214 +0x5a
created by testing.(*B).run1
	/usr/local/Cellar/go/1.11.4/libexec/src/testing/benchmark.go:207 +0x7d

goroutine 9 [IO wait]:
internal/poll.runtime_pollWait(0x1f14f30, 0x72, 0x0)
	/usr/local/Cellar/go/1.11.4/libexec/src/runtime/netpoll.go:173 +0x66
internal/poll.(*pollDesc).wait(0xc00015e098, 0x72, 0xc00002e100, 0x0, 0x0)
	/usr/local/Cellar/go/1.11.4/libexec/src/internal/poll/fd_poll_runtime.go:85 +0x9a
internal/poll.(*pollDesc).waitRead(0xc00015e098, 0xffffffffffffff00, 0x0, 0x0)
	/usr/local/Cellar/go/1.11.4/libexec/src/internal/poll/fd_poll_runtime.go:90 +0x3d
internal/poll.(*FD).Accept(0xc00015e080, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/usr/local/Cellar/go/1.11.4/libexec/src/internal/poll/fd_unix.go:384 +0x1a0
net.(*netFD).accept(0xc00015e080, 0x192348e3, 0xc0001ba000, 0xc0001cedd0)
	/usr/local/Cellar/go/1.11.4/libexec/src/net/fd_unix.go:238 +0x42
net.(*TCPListener).accept(0xc0000c60d0, 0xc0192348e3, 0xcd30192348e3, 0x100000001)
	/usr/local/Cellar/go/1.11.4/libexec/src/net/tcpsock_posix.go:139 +0x2e
net.(*TCPListener).Accept(0xc0000c60d0, 0xc03806cdd0, 0x3806cdd0001cee28, 0x5c351fd1, 0xc0001cee28)
	/usr/local/Cellar/go/1.11.4/libexec/src/net/tcpsock.go:260 +0x47
crypto/tls.(*listener).Accept(0xc0000cf040, 0xc0001cee78, 0x18, 0xc0000a5080, 0x12e3825)
	/usr/local/Cellar/go/1.11.4/libexec/src/crypto/tls/tls.go:52 +0x37
net/http.(*Server).Serve(0xc0001344e0, 0x1686980, 0xc0000cf040, 0x0, 0x0)
	/usr/local/Cellar/go/1.11.4/libexec/src/net/http/server.go:2826 +0x22f
github.com/cockroachdb/rpc-bench.listenAndServeGRPCServeHTTP(0x1686980, 0xc0000cf040, 0xc0000a4f00, 0xc0000bc080, 0x0)
	/Users/isobel/go/src/github.com/cockroachdb/rpc-bench/rpc_test.go:242 +0x116
github.com/cockroachdb/rpc-bench.benchmarkEcho.func2(0xc0000a0180, 0x1617cb0, 0x1686980, 0xc0000cf040, 0xc0000a4f00)
	/Users/isobel/go/src/github.com/cockroachdb/rpc-bench/rpc_test.go:82 +0x44
created by github.com/cockroachdb/rpc-bench.benchmarkEcho
	/Users/isobel/go/src/github.com/cockroachdb/rpc-bench/rpc_test.go:81 +0x366

rax    0x104
rbx    0x2
rcx    0x7ffeefbff308
rdx    0x2b00
rdi    0x1a56340
rsi    0x310100003200
rbp    0x7ffeefbff390
rsp    0x7ffeefbff308
r8     0x0
r9     0xa0
r10    0x0
r11    0x202
r12    0x1a56340
r13    0x16
r14    0x310100003200
r15    0x88065c0
rip    0x7fff77d637de
rflags 0x203
cs     0x7
fs     0x0
gs     0x0
*** Test killed with quit: ran too long (1m10s).
```